### PR TITLE
DONE: Optimize state

### DIFF
--- a/backend/src/services/finance.py
+++ b/backend/src/services/finance.py
@@ -20,11 +20,11 @@ class SimulateRequest(BaseModel):
     start_cash: float
     start_year: int
     end_year: int
-    base_net_income: float
-    base_income_growth: float
-    base_expenses: float
-    base_expense_growth: float
-    base_tiers: List[Tier]
+    net_income: float
+    income_growth: float
+    expenses: float
+    expense_growth: float
+    tiers: List[Tier]
     events: List[SimEvent] = []
 
 
@@ -57,17 +57,15 @@ def simulate(req: SimulateRequest) -> list:
     snapshots = []
 
     cash_on_hand = req.start_cash
-    net_income = req.base_net_income
-    income_growth = req.base_income_growth
-    expenses = req.base_expenses
-    expense_growth = req.base_expense_growth
-    tiers = req.base_tiers
+    net_income = req.net_income
+    income_growth = req.income_growth
+    expenses = req.expenses
+    expense_growth = req.expense_growth
+    tiers = req.tiers
 
-    # Index events by year for quick lookup
     events_by_year = {e.year: e for e in req.events}
 
     for year in range(req.start_year, req.end_year + 1):
-        # Apply any event for this year — only override fields that are set
         event = events_by_year.get(year)
         if event:
             if event.net_income is not None:
@@ -89,7 +87,6 @@ def simulate(req: SimulateRequest) -> list:
             cash_on_hand -= monthly_expenses
             cash_on_hand = apply_tiered_interest(cash_on_hand, tiers, periods_per_year)
 
-        # Compound at end of year
         net_income = round(net_income * (1 + income_growth), 2)
         expenses = round(expenses * (1 + expense_growth), 2)
 

--- a/backend/src/services/finance.py
+++ b/backend/src/services/finance.py
@@ -79,6 +79,9 @@ def simulate(req: SimulateRequest) -> list:
             if event.tiers is not None:
                 tiers = event.tiers
 
+        start_net_income = net_income
+        start_expenses = expenses
+
         monthly_income = net_income / 12
         monthly_expenses = expenses / 12
 
@@ -93,6 +96,8 @@ def simulate(req: SimulateRequest) -> list:
         snapshots.append({
             "year": year,
             "cash_on_hand": round(cash_on_hand, 2),
+            "start_net_income": start_net_income,
+            "start_expenses": start_expenses,
             "net_income": net_income,
             "expenses": expenses,
         })

--- a/frontend/app/dashboard/constants.tsx
+++ b/frontend/app/dashboard/constants.tsx
@@ -1,0 +1,38 @@
+import { Asset, DEFAULT_GROWTH_RATES } from "@/components/Dashboard/Assets/types";
+
+export const API = "http://localhost:8000/api/finance/simulate/";
+
+export const INITIAL_ASSETS: Asset[] = [
+  {
+    id: 1,
+    name: "Rental House",
+    type: "house",
+    value: 250000,
+    downPayment: 50000,
+    monthlyExpense: 1800,
+    sold: false,
+    compound: DEFAULT_GROWTH_RATES.house,
+    year: 0,
+  },
+  {
+    id: 2,
+    name: "Gold Bar",
+    type: "gold",
+    value: 3000,
+    downPayment: 0,
+    monthlyExpense: 0,
+    sold: false,
+    compound: DEFAULT_GROWTH_RATES.gold,
+    year: 0,
+  },
+];
+
+export const CASH_ON_HAND_DEFAULTS = {
+  start_cash: 0,
+  net_income: 80000,
+  income_growth: 0.03,
+  expenses: 50000,
+  expense_growth: 0.02,
+  tiers: [{ threshold: 1000000, annual_rate: 0.03 }],
+};
+ 

--- a/frontend/app/dashboard/constants.tsx
+++ b/frontend/app/dashboard/constants.tsx
@@ -1,5 +1,7 @@
 import { Asset, DEFAULT_GROWTH_RATES } from "@/components/Dashboard/Assets/types";
 
+export const SIM_MAX = 30;
+
 export const API = "http://localhost:8000/api/finance/simulate/";
 
 export const INITIAL_ASSETS: Asset[] = [
@@ -33,6 +35,6 @@ export const CASH_ON_HAND_DEFAULTS = {
   income_growth: 0.03,
   expenses: 50000,
   expense_growth: 0.02,
-  tiers: [{ threshold: 1000000, annual_rate: 0.03 }],
+  tiers: [{ threshold: 100000, annual_rate: 0.1 }, { threshold: 500000, annual_rate: 0.15 }],
 };
  

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -47,7 +47,7 @@ export default function Dashboard() {
               inputs={sim.currentInputs}
               result={sim.currentResult}
               displayResult={sim.displayResult}
-              onUpdate={(changes) => sim.updateEvent({ year: sim.currentYear, ...changes })}
+              onUpdate={sim.updateEvent}
             />
           </div>
 

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,245 +1,18 @@
 "use client";
 import "./dashboard.css";
-import { useState, useEffect, useRef } from "react";
+import { useState } from "react";
 import CashOnHandCalc from "@/components/Dashboard/CashOnHandCalc/CashOnHandCalc";
 import SimControls from "@/components/Dashboard/SimControls/SimControls";
 import AssetPortfolio from "@/components/Dashboard/Assets/AssetPortfolio";
-import { Asset, NewAsset, DEFAULT_GROWTH_RATES } from "@/components/Dashboard/Assets/types";
+import { Asset } from "@/components/Dashboard/Assets/types";
+import { INITIAL_ASSETS } from "@/app/dashboard/constants";
+import { useSimulation } from "./useSimulation";
 
 export const SIM_MAX = 30;
-const API = "http://localhost:8000/api/finance/simulate/";
-
-const INITIAL_ASSETS: Asset[] = [
-  {
-    id: 1,
-    name: "Rental House",
-    type: "house",
-    value: 250000,
-    downPayment: 50000,
-    monthlyExpense: 1800,
-    sold: false,
-    compound: DEFAULT_GROWTH_RATES.house,
-    year: 0,
-  },
-  {
-    id: 2,
-    name: "Gold Bar",
-    type: "gold",
-    value: 3000,
-    downPayment: 0,
-    monthlyExpense: 0,
-    sold: false,
-    compound: DEFAULT_GROWTH_RATES.gold,
-    year: 0,
-  },
-];
-
-const CashOnHandDefaults = {
-  start_cash: 0,
-  base_net_income: 80000,
-  base_income_growth: 0.03,
-  base_expenses: 50000,
-  base_expense_growth: 0.02,
-  base_tiers: [{ threshold: 1000000, annual_rate: 0.03 }],
-};
-
-export interface Tier {
-  threshold: number;
-  annual_rate: number;
-}
-
-export interface SimEvent {
-  year: number;
-  net_income?: number;
-  income_growth?: number;
-  expenses?: number;
-  expense_growth?: number;
-  tiers?: Tier[];
-}
-
-export interface YearSnapshot {
-  year: number;
-  cash_on_hand: number;
-  net_income: number;
-  expenses: number;
-}
-
-function getBaseAtYear(events: SimEvent[], beforeYear: number) {
-  const priorEvents = events.filter((e) => e.year < beforeYear);
-  return priorEvents.reduce(
-    (base, ev) => ({
-      base_net_income: ev.net_income ?? base.base_net_income,
-      base_income_growth: ev.income_growth ?? base.base_income_growth,
-      base_expenses: ev.expenses ?? base.base_expenses,
-      base_expense_growth: ev.expense_growth ?? base.base_expense_growth,
-      base_tiers: ev.tiers ?? base.base_tiers,
-    }),
-    {
-      base_net_income: CashOnHandDefaults.base_net_income,
-      base_income_growth: CashOnHandDefaults.base_income_growth,
-      base_expenses: CashOnHandDefaults.base_expenses,
-      base_expense_growth: CashOnHandDefaults.base_expense_growth,
-      base_tiers: CashOnHandDefaults.base_tiers,
-    }
-  );
-}
 
 export default function Dashboard() {
-  const [events, setEvents] = useState<SimEvent[]>([]);
-  const [results, setResults] = useState<YearSnapshot[]>([]);
-  const [currentYear, setCurrentYear] = useState(1);
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [dirtyFromYear, setDirtyFromYear] = useState<number | null>(1);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const currentResult = results.find((r) => r.year === currentYear) ?? null;
-  const lastResult = [...results].reverse().find((r) => r.year <= currentYear) ?? null;
-  const displayResult = currentResult ?? (isPlaying ? lastResult : null);
-
-  const currentEvent = events.find((e) => e.year === currentYear);
-  const currentInputs = {
-    net_income: currentResult?.net_income ?? currentEvent?.net_income ?? CashOnHandDefaults.base_net_income,
-    income_growth: currentEvent?.income_growth ?? CashOnHandDefaults.base_income_growth,
-    expenses: currentResult?.expenses ?? currentEvent?.expenses ?? CashOnHandDefaults.base_expenses,
-    expense_growth: currentEvent?.expense_growth ?? CashOnHandDefaults.base_expense_growth,
-    tiers: currentEvent?.tiers ?? CashOnHandDefaults.base_tiers,
-  };
-
-  const play = async () => {
-    if (dirtyFromYear !== null) await runSimulation(dirtyFromYear);
-    setIsPlaying(true);
-  };
-
-  const pause = () => {
-    setIsPlaying(false);
-    if (timerRef.current) clearTimeout(timerRef.current);
-  };
-
-  const reset = () => {
-    pause();
-    setCurrentYear(1);
-    setEvents([]);
-    setResults([]);
-    setDirtyFromYear(1);
-    setError(null);
-  };
-
-  const seekTo = (year: number) => {
-    pause();
-    setCurrentYear(Math.max(1, Math.min(SIM_MAX, year)));
-  };
-
-  // completely separate from cash simulation
   const [assets, setAssets] = useState<Asset[]>(INITIAL_ASSETS);
-
-  useEffect(() => {
-    if (!isPlaying) return;
-    if (currentYear >= SIM_MAX) {
-      setIsPlaying(false);
-      return;
-    }
-    timerRef.current = setTimeout(() => setCurrentYear((y) => y + 1), 600);
-    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
-  }, [isPlaying, currentYear]);
-
-  const runSimulation = async (fromYear: number) => {
-    setError(null);
-    try {
-      const prevResult = [...results].reverse().find((r) => r.year === fromYear - 1);
-
-      // Get the effective base by replaying all events before fromYear
-      // so growth rates and settings from past edits carry forward correctly
-      const base = getBaseAtYear(events, fromYear);
-
-      const payload = {
-        ...base,
-        start_cash: prevResult?.cash_on_hand ?? CashOnHandDefaults.start_cash,
-        start_year: fromYear,
-        end_year: SIM_MAX,
-        events: events.filter((e) => e.year >= fromYear),
-      };
-
-      const res = await fetch(API, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) throw new Error(`${res.status}: ${res.statusText}`);
-      const snapshots: YearSnapshot[] = await res.json();
-
-      console.log(`payload: ${JSON.stringify(payload, null, 2)}`);
-      console.log(`snapshots: ${JSON.stringify(snapshots, null, 2)}`);
-      setResults((prev) => [...prev.filter((r) => r.year < fromYear), ...snapshots]);
-      setDirtyFromYear(null);
-    } catch (err) {
-      setError((err as Error).message);
-    }
-  };
-
-  const updateEvent = (event: SimEvent) => {
-    setEvents((prev) =>
-      [...prev.filter((e) => e.year !== event.year), event].sort((a, b) => a.year - b.year)
-    );
-    setDirtyFromYear((prev) => (prev === null ? event.year : Math.min(prev, event.year)));
-    setResults((prev) => prev.filter((r) => r.year < event.year));
-  };
-
-  const addAsset = (asset: NewAsset) => {
-    setAssets((prev) => {
-      const nextId =
-        prev.length > 0 ? Math.max(...prev.map((a) => a.id)) + 1 : 1;
-
-      return [
-        ...prev,
-        {
-          id: nextId,
-          sold: false,
-          ...asset,
-        },
-      ];
-    });
-  };
-
-  
-  
-  const sellAsset = (id: number) => {
-  setAssets((prev) =>
-    prev.map((asset) => {
-      if (asset.id !== id) return asset;
-
-      const yearsHeld = Math.max(0, currentYear - asset.year);
-      const soldAmount = asset.value * Math.pow(1 + asset.compound, yearsHeld);
-
-      return {
-        ...asset,
-        sold: true,
-        soldYear: currentYear,
-        saleValue: soldAmount,
-      };
-    })
-  );
-};
-
-const computedAssets = assets.map((asset) => {
-  const growthEndYear =
-    asset.sold && asset.soldYear !== undefined
-      ? Math.min(currentYear, asset.soldYear)
-      : currentYear;
-
-  const yearsHeld = Math.max(0, growthEndYear - asset.year);
-
-  const currentValue = asset.value * Math.pow(1 + asset.compound, yearsHeld);
-
-  return {
-    ...asset,
-    currentValue,
-  };
-});
-
-
-  const status =
-    isPlaying ? "playing" : dirtyFromYear !== null ? "edited" : currentYear >= SIM_MAX ? "done" : "paused";
+  const sim = useSimulation();
 
   return (
     <div className="dash-root">
@@ -270,19 +43,19 @@ const computedAssets = assets.map((asset) => {
         <div className="dash-grid">
           <div className="dash-cell dash-cell-md">
             <CashOnHandCalc
-              currentYear={currentYear}
-              inputs={currentInputs}
-              result={currentResult}
-              displayResult={displayResult}
-              onUpdate={(changes) => updateEvent({ year: currentYear, ...changes })}
+              currentYear={sim.currentYear}
+              inputs={sim.currentInputs}
+              result={sim.currentResult}
+              displayResult={sim.displayResult}
+              onUpdate={(changes) => sim.updateEvent({ year: sim.currentYear, ...changes })}
             />
           </div>
 
           <div className="dash-cell dash-cell-md">
             <AssetPortfolio
-              assets={computedAssets}
-              onAddAsset={addAsset}
-              onSell={sellAsset}
+              assets={assets}
+              currentYear={sim.currentYear}
+              onAssetsChange={setAssets}
             />
           </div>
 
@@ -296,19 +69,19 @@ const computedAssets = assets.map((asset) => {
 
           <div className="dash-cell dash-cell-sm">
             <SimControls
-              currentYear={currentYear}
-              isPlaying={isPlaying}
-              status={status}
+              currentYear={sim.currentYear}
+              isPlaying={sim.isPlaying}
+              status={sim.status}
               simMax={SIM_MAX}
-              onPlay={play}
-              onPause={pause}
-              onReset={reset}
-              onSeek={seekTo}
+              onPlay={sim.play}
+              onPause={sim.pause}
+              onReset={sim.reset}
+              onSeek={sim.seekTo}
             />
           </div>
         </div>
 
-        {error && <div className="dash-error">{error}</div>}
+        {sim.error && <div className="dash-error">{sim.error}</div>}
       </main>
     </div>
   );

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -39,9 +39,6 @@ const DEFAULTS = {
   base_tiers: [{ threshold: 1000000, annual_rate: 0.03 }],
 };
 
-// Derive the effective base values by replaying all events before a given year.
-// This ensures growth rates and other settings carry forward correctly
-// when restarting the simulation from mid-timeline.
 function getBaseAtYear(events: SimEvent[], beforeYear: number) {
   const priorEvents = events.filter((e) => e.year < beforeYear);
   return priorEvents.reduce(

--- a/frontend/app/dashboard/useSimulation.tsx
+++ b/frontend/app/dashboard/useSimulation.tsx
@@ -1,0 +1,147 @@
+import { useState, useEffect, useRef } from "react";
+import { CASH_ON_HAND_DEFAULTS, API } from "@/app/dashboard/constants";
+import { SIM_MAX } from "./page";
+
+export interface Tier {
+  threshold: number;
+  annual_rate: number;
+}
+
+export interface SimEvent {
+  year: number;
+  net_income?: number;
+  income_growth?: number;
+  expenses?: number;
+  expense_growth?: number;
+  tiers?: Tier[];
+}
+
+export interface YearSnapshot {
+  year: number;
+  cash_on_hand: number;
+  net_income: number;
+  expenses: number;
+}
+
+// Gets all events prior to beforeYear and replays them in order, last write wins per field.
+function resolveParamsAtYear(events: SimEvent[], beforeYear: number) {
+  const base = { ...CASH_ON_HAND_DEFAULTS };
+  for (const ev of events.filter((e) => e.year < beforeYear)) {
+    if (ev.net_income !== undefined) base.net_income = ev.net_income;
+    if (ev.income_growth !== undefined) base.income_growth = ev.income_growth;
+    if (ev.expenses !== undefined) base.expenses = ev.expenses;
+    if (ev.expense_growth !== undefined) base.expense_growth = ev.expense_growth;
+    if (ev.tiers !== undefined) base.tiers = ev.tiers;
+  }
+  return base;
+}
+
+function buildPayload(events: SimEvent[], results: YearSnapshot[], fromYear: number) {
+  const prevResult = [...results].reverse().find((r) => r.year === fromYear - 1);
+  return {
+    ...resolveParamsAtYear(events, fromYear),
+    start_cash: prevResult?.cash_on_hand ?? CASH_ON_HAND_DEFAULTS.start_cash,
+    start_year: fromYear,
+    end_year: SIM_MAX,
+    events: events.filter((e) => e.year >= fromYear),
+  };
+}
+
+export function useSimulation() {
+  const [events, setEvents] = useState<SimEvent[]>([]);
+  const [results, setResults] = useState<YearSnapshot[]>([]);
+  const [currentYear, setCurrentYear] = useState(1);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [rerunFromYear, setRerunFromYear] = useState<number | null>(1);
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const currentResult = results.find((r) => r.year === currentYear) ?? null;
+  const lastResult = [...results].reverse().find((r) => r.year <= currentYear) ?? null;
+  const displayResult = currentResult ?? (isPlaying ? lastResult : null);
+
+  const currentEvent = events.find((e) => e.year === currentYear);
+  const currentInputs = {
+    net_income: currentResult?.net_income ?? currentEvent?.net_income ?? CASH_ON_HAND_DEFAULTS.net_income,
+    income_growth: currentEvent?.income_growth ?? CASH_ON_HAND_DEFAULTS.income_growth,
+    expenses: currentResult?.expenses ?? currentEvent?.expenses ?? CASH_ON_HAND_DEFAULTS.expenses,
+    expense_growth: currentEvent?.expense_growth ?? CASH_ON_HAND_DEFAULTS.expense_growth,
+    tiers: currentEvent?.tiers ?? CASH_ON_HAND_DEFAULTS.tiers,
+  };
+
+  const status =
+    isPlaying ? "playing" : rerunFromYear !== null ? "edited" : currentYear >= SIM_MAX ? "done" : "paused";
+
+  const runSimulation = async (fromYear: number) => {
+    setError(null);
+    try {
+      const payload = buildPayload(events, results, fromYear);
+      const res = await fetch(API, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error(`${res.status}: ${res.statusText}`);
+      const snapshots: YearSnapshot[] = await res.json();
+      setResults((prev) => [...prev.filter((r) => r.year < fromYear), ...snapshots]);
+      setRerunFromYear(null);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const play = async () => {
+    if (rerunFromYear !== null) await runSimulation(rerunFromYear);
+    setIsPlaying(true);
+  };
+
+  const pause = () => {
+    setIsPlaying(false);
+    if (timerRef.current) clearTimeout(timerRef.current);
+  };
+
+  const reset = () => {
+    pause();
+    setCurrentYear(1);
+    setEvents([]);
+    setResults([]);
+    setRerunFromYear(1);
+    setError(null);
+  };
+
+  const seekTo = (year: number) => {
+    pause();
+    setCurrentYear(Math.max(1, Math.min(SIM_MAX, year)));
+  };
+
+  const updateEvent = (event: SimEvent) => {
+    setEvents((prev) =>
+      [...prev.filter((e) => e.year !== event.year), event].sort((a, b) => a.year - b.year)
+    );
+    setRerunFromYear((prev) => (prev === null ? event.year : Math.min(prev, event.year)));
+    setResults((prev) => prev.filter((r) => r.year < event.year));
+  };
+
+  useEffect(() => {
+    if (!isPlaying) return;
+    if (currentYear >= SIM_MAX) { setIsPlaying(false); return; }
+    timerRef.current = setTimeout(() => setCurrentYear((y) => y + 1), 600);
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  }, [isPlaying, currentYear]);
+
+  return {
+    currentYear,
+    isPlaying,
+    status,
+    error,
+    currentInputs,
+    currentResult,
+    displayResult,
+    play,
+    pause,
+    reset,
+    seekTo,
+    updateEvent,
+  };
+}

--- a/frontend/app/dashboard/useSimulation.tsx
+++ b/frontend/app/dashboard/useSimulation.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useRef } from "react";
-import { CASH_ON_HAND_DEFAULTS, API } from "@/app/dashboard/constants";
-import { SIM_MAX } from "./page";
+import { useReducer, useEffect, useRef } from "react";
+import { API, SIM_MAX } from "@/app/dashboard/constants";
+import { getSimParamsAsOf, buildPayload } from "./utils";
 
 export interface Tier {
   threshold: number;
@@ -19,41 +19,82 @@ export interface SimEvent {
 export interface YearSnapshot {
   year: number;
   cash_on_hand: number;
+  start_net_income: number;
+  start_expenses: number;
   net_income: number;
   expenses: number;
 }
 
-// Gets all events prior to beforeYear and replays them in order, last write wins per field.
-function resolveParamsAtYear(events: SimEvent[], beforeYear: number) {
-  const base = { ...CASH_ON_HAND_DEFAULTS };
-  for (const ev of events.filter((e) => e.year < beforeYear)) {
-    if (ev.net_income !== undefined) base.net_income = ev.net_income;
-    if (ev.income_growth !== undefined) base.income_growth = ev.income_growth;
-    if (ev.expenses !== undefined) base.expenses = ev.expenses;
-    if (ev.expense_growth !== undefined) base.expense_growth = ev.expense_growth;
-    if (ev.tiers !== undefined) base.tiers = ev.tiers;
+// ─── State ────────────────────────────────────────────────────────────────────
+
+type SimState = {
+  events: SimEvent[];
+  results: YearSnapshot[];
+  currentYear: number;
+  isPlaying: boolean;
+  error: string | null;
+  rerunFromYear: number | null;
+};
+
+const INITIAL_STATE: SimState = {
+  events: [],
+  results: [],
+  currentYear: 1,
+  isPlaying: false,
+  error: null,
+  rerunFromYear: 1,
+};
+
+// ─── Actions ──────────────────────────────────────────────────────────────────
+
+type SimAction =
+  | { type: "UPDATE_EVENT"; event: SimEvent }
+  | { type: "SIMULATION_COMPLETE"; fromYear: number; snapshots: YearSnapshot[] }
+  | { type: "SIMULATION_ERROR"; error: string }
+  | { type: "SET_PLAYING"; isPlaying: boolean }
+  | { type: "SEEK"; year: number }
+  | { type: "ADVANCE_YEAR" }
+  | { type: "RESET" };
+
+// ─── Reducer ──────────────────────────────────────────────────────────────────
+
+function simReducer(state: SimState, action: SimAction): SimState {
+  switch (action.type) {
+    case "UPDATE_EVENT":
+      return {
+        ...state,
+        events: [...state.events.filter((e) => e.year !== action.event.year), action.event]
+          .sort((a, b) => a.year - b.year),
+        rerunFromYear: state.rerunFromYear === null
+          ? action.event.year
+          : Math.min(state.rerunFromYear, action.event.year),
+        results: state.results.filter((r) => r.year < action.event.year),
+      };
+    case "SIMULATION_COMPLETE":
+      return {
+        ...state,
+        results: [...state.results.filter((r) => r.year < action.fromYear), ...action.snapshots],
+        rerunFromYear: null,
+        error: null,
+      };
+    case "SIMULATION_ERROR":
+      return { ...state, error: action.error };
+    case "SET_PLAYING":
+      return { ...state, isPlaying: action.isPlaying };
+    case "SEEK":
+      return { ...state, isPlaying: false, currentYear: Math.max(1, Math.min(SIM_MAX, action.year)) };
+    case "ADVANCE_YEAR":
+      return { ...state, currentYear: state.currentYear + 1 };
+    case "RESET":
+      return { ...INITIAL_STATE };
   }
-  return base;
 }
 
-function buildPayload(events: SimEvent[], results: YearSnapshot[], fromYear: number) {
-  const prevResult = [...results].reverse().find((r) => r.year === fromYear - 1);
-  return {
-    ...resolveParamsAtYear(events, fromYear),
-    start_cash: prevResult?.cash_on_hand ?? CASH_ON_HAND_DEFAULTS.start_cash,
-    start_year: fromYear,
-    end_year: SIM_MAX,
-    events: events.filter((e) => e.year >= fromYear),
-  };
-}
+// ─── Hook ─────────────────────────────────────────────────────────────────────
 
 export function useSimulation() {
-  const [events, setEvents] = useState<SimEvent[]>([]);
-  const [results, setResults] = useState<YearSnapshot[]>([]);
-  const [currentYear, setCurrentYear] = useState(1);
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [rerunFromYear, setRerunFromYear] = useState<number | null>(1);
+  const [state, dispatch] = useReducer(simReducer, INITIAL_STATE);
+  const { events, results, currentYear, isPlaying, error, rerunFromYear } = state;
 
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -62,19 +103,19 @@ export function useSimulation() {
   const displayResult = currentResult ?? (isPlaying ? lastResult : null);
 
   const currentEvent = events.find((e) => e.year === currentYear);
+  const resolvedBase = getSimParamsAsOf(events, currentYear);
   const currentInputs = {
-    net_income: currentResult?.net_income ?? currentEvent?.net_income ?? CASH_ON_HAND_DEFAULTS.net_income,
-    income_growth: currentEvent?.income_growth ?? CASH_ON_HAND_DEFAULTS.income_growth,
-    expenses: currentResult?.expenses ?? currentEvent?.expenses ?? CASH_ON_HAND_DEFAULTS.expenses,
-    expense_growth: currentEvent?.expense_growth ?? CASH_ON_HAND_DEFAULTS.expense_growth,
-    tiers: currentEvent?.tiers ?? CASH_ON_HAND_DEFAULTS.tiers,
+    net_income: currentResult?.net_income ?? currentEvent?.net_income ?? resolvedBase.net_income,
+    income_growth: currentEvent?.income_growth ?? resolvedBase.income_growth,
+    expenses: currentResult?.expenses ?? currentEvent?.expenses ?? resolvedBase.expenses,
+    expense_growth: currentEvent?.expense_growth ?? resolvedBase.expense_growth,
+    tiers: currentEvent?.tiers ?? resolvedBase.tiers,
   };
 
   const status =
     isPlaying ? "playing" : rerunFromYear !== null ? "edited" : currentYear >= SIM_MAX ? "done" : "paused";
 
   const runSimulation = async (fromYear: number) => {
-    setError(null);
     try {
       const payload = buildPayload(events, results, fromYear);
       const res = await fetch(API, {
@@ -84,49 +125,40 @@ export function useSimulation() {
       });
       if (!res.ok) throw new Error(`${res.status}: ${res.statusText}`);
       const snapshots: YearSnapshot[] = await res.json();
-      setResults((prev) => [...prev.filter((r) => r.year < fromYear), ...snapshots]);
-      setRerunFromYear(null);
+      dispatch({ type: "SIMULATION_COMPLETE", fromYear, snapshots });
     } catch (err) {
-      setError((err as Error).message);
+      dispatch({ type: "SIMULATION_ERROR", error: (err as Error).message });
     }
   };
 
   const play = async () => {
     if (rerunFromYear !== null) await runSimulation(rerunFromYear);
-    setIsPlaying(true);
+    dispatch({ type: "SET_PLAYING", isPlaying: true });
   };
 
   const pause = () => {
-    setIsPlaying(false);
     if (timerRef.current) clearTimeout(timerRef.current);
+    dispatch({ type: "SET_PLAYING", isPlaying: false });
   };
 
   const reset = () => {
-    pause();
-    setCurrentYear(1);
-    setEvents([]);
-    setResults([]);
-    setRerunFromYear(1);
-    setError(null);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    dispatch({ type: "RESET" });
   };
 
   const seekTo = (year: number) => {
-    pause();
-    setCurrentYear(Math.max(1, Math.min(SIM_MAX, year)));
+    if (timerRef.current) clearTimeout(timerRef.current);
+    dispatch({ type: "SEEK", year });
   };
 
   const updateEvent = (event: SimEvent) => {
-    setEvents((prev) =>
-      [...prev.filter((e) => e.year !== event.year), event].sort((a, b) => a.year - b.year)
-    );
-    setRerunFromYear((prev) => (prev === null ? event.year : Math.min(prev, event.year)));
-    setResults((prev) => prev.filter((r) => r.year < event.year));
+    dispatch({ type: "UPDATE_EVENT", event });
   };
 
   useEffect(() => {
     if (!isPlaying) return;
-    if (currentYear >= SIM_MAX) { setIsPlaying(false); return; }
-    timerRef.current = setTimeout(() => setCurrentYear((y) => y + 1), 600);
+    if (currentYear >= SIM_MAX) { dispatch({ type: "SET_PLAYING", isPlaying: false }); return; }
+    timerRef.current = setTimeout(() => dispatch({ type: "ADVANCE_YEAR" }), 600);
     return () => { if (timerRef.current) clearTimeout(timerRef.current); };
   }, [isPlaying, currentYear]);
 

--- a/frontend/app/dashboard/utils.tsx
+++ b/frontend/app/dashboard/utils.tsx
@@ -1,0 +1,58 @@
+
+import { CASH_ON_HAND_DEFAULTS } from "@/app/dashboard/constants";
+import { SIM_MAX } from "@/app/dashboard/constants";
+import type { SimEvent, YearSnapshot } from "./useSimulation";
+
+export function diffInputs<T extends object>(original: T, edited: T): Partial<T> {
+  const changes: Partial<T> = {};
+  for (const key of Object.keys(edited) as (keyof T)[]) {
+    if (JSON.stringify(edited[key]) !== JSON.stringify(original[key])) {
+      (changes as Record<keyof T, unknown>)[key] = edited[key];
+    }
+  }
+  return changes;
+}
+
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+// function resolveParamsAtYear(events: SimEvent[], beforeYear: number) {
+//   const base = { ...CASH_ON_HAND_DEFAULTS };
+//   for (const ev of events.filter((e) => e.year < beforeYear)) {
+//     if (ev.net_income !== undefined) base.net_income = ev.net_income;
+//     if (ev.income_growth !== undefined) base.income_growth = ev.income_growth;
+//     if (ev.expenses !== undefined) base.expenses = ev.expenses;
+//     if (ev.expense_growth !== undefined) base.expense_growth = ev.expense_growth;
+//     if (ev.tiers !== undefined) base.tiers = ev.tiers;
+//   }
+//   return base;
+// }
+
+// This is called twice per render — once for resolvedBase in currentInputs, 
+// and once inside buildPayload when play is hit. 
+// Not a performance concern now, but worth noting if the events array grows large
+export function getSimParamsAsOf(events: SimEvent[], beforeYear: number) {
+  const base = { ...CASH_ON_HAND_DEFAULTS };
+  for (const ev of events.filter((e) => e.year < beforeYear)) {
+    for (const key of Object.keys(ev) as (keyof SimEvent)[]) {
+      if (key !== "year" && ev[key] !== undefined) {
+        (base as Record<string, unknown>)[key] = ev[key];
+      }
+    }
+  }
+  return base;
+}
+
+export function buildPayload(events: SimEvent[], results: YearSnapshot[], fromYear: number) {
+  const prevResult = [...results].reverse().find((r) => r.year === fromYear - 1);
+  return {
+    ...getSimParamsAsOf(events, fromYear),
+    start_cash: prevResult?.cash_on_hand ?? CASH_ON_HAND_DEFAULTS.start_cash,
+    start_year: fromYear,
+    end_year: SIM_MAX,
+    events: events.filter((e) => e.year >= fromYear),
+  };
+}
+
+
+

--- a/frontend/components/Dashboard/Assets/AssetPortfolio.tsx
+++ b/frontend/components/Dashboard/Assets/AssetPortfolio.tsx
@@ -6,55 +6,60 @@ import AssetActions from "./AssetActions";
 import AssetSummary from "./AssetSummary";
 import AssetList from "./AssetList";
 
-
-type DisplayAsset = Asset & {
-  currentValue: number;
-};
-
 type AssetPortfolioProps = {
-  assets: DisplayAsset[];
-  onAddAsset: (asset: NewAsset) => void;
-  onSell: (id: number) => void;
+  assets: Asset[];
+  currentYear: number;
+  onAssetsChange: (assets: Asset[]) => void;
 };
 
-export default function AssetPortfolio({ assets, onAddAsset, onSell, }: AssetPortfolioProps) {
+export default function AssetPortfolio({ assets, currentYear, onAssetsChange }: AssetPortfolioProps) {
   const [showForm, setShowForm] = useState(false);
 
-  const ownedAssets = assets.filter((asset) => !asset.sold);
-
-  const totalAssetValue = ownedAssets.reduce((sum, asset) => sum + asset.currentValue, 0);
-  const totalMonthlyExpenses = ownedAssets.reduce(
-    (sum, asset) => sum + (asset.monthlyExpense ?? 0),
-    0
-  );
-
-  const handleAddAsset = (asset: NewAsset) => {
-    onAddAsset(asset);
+  const addAsset = (asset: NewAsset) => {
+    const nextId = assets.length > 0 ? Math.max(...assets.map((a) => a.id)) + 1 : 1;
+    onAssetsChange([...assets, { id: nextId, sold: false, ...asset }]);
     setShowForm(false);
   };
+
+  const sellAsset = (id: number) => {
+    onAssetsChange(
+      assets.map((asset) => {
+        if (asset.id !== id) return asset;
+        const yearsHeld = Math.max(0, currentYear - asset.year);
+        const soldAmount = asset.value * Math.pow(1 + asset.compound, yearsHeld);
+        return { ...asset, sold: true, soldYear: currentYear, saleValue: soldAmount };
+      })
+    );
+  };
+
+  const computedAssets = assets.map((asset) => {
+    const growthEndYear =
+      asset.sold && asset.soldYear !== undefined
+        ? Math.min(currentYear, asset.soldYear)
+        : currentYear;
+    const yearsHeld = Math.max(0, growthEndYear - asset.year);
+    const currentValue = asset.value * Math.pow(1 + asset.compound, yearsHeld);
+    return { ...asset, currentValue };
+  });
+
+  const ownedAssets = computedAssets.filter((asset) => !asset.sold);
+  const totalAssetValue = ownedAssets.reduce((sum, asset) => sum + asset.currentValue, 0);
+  const totalMonthlyExpenses = ownedAssets.reduce((sum, asset) => sum + (asset.monthlyExpense ?? 0), 0);
 
   return (
     <section className="asset-panel">
       <div className="asset-panel-header">
         <h2 className="asset-panel-title">Asset Portfolio</h2>
-        <button
-          type="button"
-          className="asset-button asset-button-teal"
-          onClick={() => setShowForm((prev) => !prev)}
-        >
+        <button type="button" className="asset-button asset-button-teal" onClick={() => setShowForm((prev) => !prev)} >
           {showForm ? "Close" : "+ Add Asset"}
         </button>
       </div>
 
-      <AssetSummary
-        totalAssetValue={totalAssetValue}
-        totalMonthlyExpenses={totalMonthlyExpenses}
-        ownedCount={ownedAssets.length}
-      />
+      <AssetSummary totalAssetValue={totalAssetValue} totalMonthlyExpenses={totalMonthlyExpenses} ownedCount={ownedAssets.length} />
 
-      {showForm && <AssetActions onAddAsset={handleAddAsset} />}
+      {showForm && <AssetActions onAddAsset={addAsset} />}
 
-      <AssetList assets={assets} onSell={onSell} />
+      <AssetList assets={computedAssets} onSell={sellAsset} />
     </section>
   );
 }

--- a/frontend/components/Dashboard/Assets/AssetSummary.tsx
+++ b/frontend/components/Dashboard/Assets/AssetSummary.tsx
@@ -4,11 +4,7 @@ type AssetSummaryProps = {
   ownedCount: number;
 };
 
-export default function AssetSummary({
-  totalAssetValue,
-  totalMonthlyExpenses,
-  ownedCount,
-}: AssetSummaryProps) {
+export default function AssetSummary({ totalAssetValue, totalMonthlyExpenses, ownedCount, }: AssetSummaryProps) {
   return (
     <section className="asset-summary">
       <p className="asset-summary-label">Portfolio Value</p>

--- a/frontend/components/Dashboard/Assets/types.ts
+++ b/frontend/components/Dashboard/Assets/types.ts
@@ -14,12 +14,9 @@ export type Asset = {
 
     soldYear?: number;
     soldValue?: number;
-    
-
 };
 
 export type NewAsset= {
-
     name: string;
     type: AssetType;
     value: number;
@@ -27,7 +24,6 @@ export type NewAsset= {
     monthlyExpense: number;
     compound: number;
     year: number;
-
 }
 
 

--- a/frontend/components/Dashboard/CashOnHandCalc/CashOnHandCalc.tsx
+++ b/frontend/components/Dashboard/CashOnHandCalc/CashOnHandCalc.tsx
@@ -1,7 +1,7 @@
 "use client";
 import "./CashOnHandCalc.css";
 import { useState } from "react";
-import { YearSnapshot, Tier } from "@/app/dashboard/page";
+import { YearSnapshot, Tier } from "@/app/dashboard/useSimulation";
 
 interface Inputs {
   net_income: number;
@@ -26,7 +26,7 @@ export default function CashOnHandCalc({ currentYear, inputs, result, displayRes
   const [draft, setDraft] = useState<Inputs | null>(null);
   const [open, setOpen] = useState(false);
 
-  const updateTier = (i: number, field: keyof Tier, value: number) => {
+  const updateTier = (i: number, field: keyof Tier, value: number): void => {
     if (!draft) return;
     const tiers = [...draft.tiers];
     tiers[i] = { ...tiers[i], [field]: value };

--- a/frontend/components/Dashboard/CashOnHandCalc/CashOnHandCalc.tsx
+++ b/frontend/components/Dashboard/CashOnHandCalc/CashOnHandCalc.tsx
@@ -1,7 +1,8 @@
 "use client";
 import "./CashOnHandCalc.css";
 import { useState } from "react";
-import { YearSnapshot, Tier } from "@/app/dashboard/useSimulation";
+import { YearSnapshot, Tier, SimEvent } from "@/app/dashboard/useSimulation";
+import { diffInputs } from "@/app/dashboard/utils";
 
 interface Inputs {
   net_income: number;
@@ -16,7 +17,7 @@ interface Props {
   inputs: Inputs;
   result: YearSnapshot | null;
   displayResult: YearSnapshot | null;
-  onUpdate: (changes: Partial<Inputs>) => void;
+  onUpdate: (event: SimEvent) => void;
 }
 
 const fmt = (n: number) => n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
@@ -26,7 +27,17 @@ export default function CashOnHandCalc({ currentYear, inputs, result, displayRes
   const [draft, setDraft] = useState<Inputs | null>(null);
   const [open, setOpen] = useState(false);
 
-  const updateTier = (i: number, field: keyof Tier, value: number): void => {
+  const openModal = () => {
+    setDraft(structuredClone(inputs));
+    setOpen(true);
+  };
+
+  const closeModal = () => {
+    setDraft(null);
+    setOpen(false);
+  };
+
+  const updateTier = (i: number, field: keyof Tier, value: number) => {
     if (!draft) return;
     const tiers = [...draft.tiers];
     tiers[i] = { ...tiers[i], [field]: value };
@@ -35,8 +46,9 @@ export default function CashOnHandCalc({ currentYear, inputs, result, displayRes
 
   const handleSave = () => {
     if (!draft) return;
-    onUpdate(draft);
-    setOpen(false);
+    const changes = diffInputs(inputs, draft);
+    if (Object.keys(changes).length > 0) onUpdate({ year: currentYear, ...changes });
+    closeModal();
   };
 
   return (
@@ -44,9 +56,7 @@ export default function CashOnHandCalc({ currentYear, inputs, result, displayRes
       <div className="coh-card">
         <div className="coh-card-header">
           <span className="coh-card-title">Cash on Hand</span>
-          <button className="coh-edit-btn" onClick={() => { setDraft(structuredClone(inputs)); setOpen(true); }}>
-            Edit
-          </button>
+          <button className="coh-edit-btn" onClick={openModal}>Edit</button>
         </div>
 
         <div className="coh-stat-grid">
@@ -55,21 +65,41 @@ export default function CashOnHandCalc({ currentYear, inputs, result, displayRes
             <span className="coh-stat-value">{currentYear}</span>
           </div>
           <div className="coh-stat">
-            <span className="coh-stat-label">Net Income</span>
-            <span className="coh-stat-value">${fmt(inputs.net_income)}</span>
-          </div>
-          <div className="coh-stat">
             <span className="coh-stat-label">Income Growth</span>
             <span className="coh-stat-value">{pct(inputs.income_growth)}</span>
-          </div>
-          <div className="coh-stat">
-            <span className="coh-stat-label">Expenses</span>
-            <span className="coh-stat-value">${fmt(inputs.expenses)}</span>
           </div>
           <div className="coh-stat">
             <span className="coh-stat-label">Expense Growth</span>
             <span className="coh-stat-value">{pct(inputs.expense_growth)}</span>
           </div>
+
+          <div className="coh-stat">
+            <span className="coh-stat-label">Start Net Income</span>
+            <span className="coh-stat-value">
+              {result ? `$${fmt(result.start_net_income)}` : `$${fmt(inputs.net_income)}`}
+            </span>
+          </div>
+          <div className="coh-stat">
+            <span className="coh-stat-label">End Net Income</span>
+            <span className="coh-stat-value">
+              {result ? `$${fmt(result.net_income)}` : "—"}
+            </span>
+          </div>
+          <div className="coh-stat" />
+
+          <div className="coh-stat">
+            <span className="coh-stat-label">Start Expenses</span>
+            <span className="coh-stat-value">
+              {result ? `$${fmt(result.start_expenses)}` : `$${fmt(inputs.expenses)}`}
+            </span>
+          </div>
+          <div className="coh-stat">
+            <span className="coh-stat-label">End Expenses</span>
+            <span className="coh-stat-value">
+              {result ? `$${fmt(result.expenses)}` : "—"}
+            </span>
+          </div>
+          <div className="coh-stat" />
         </div>
 
         <div className="coh-projection">
@@ -83,11 +113,11 @@ export default function CashOnHandCalc({ currentYear, inputs, result, displayRes
       </div>
 
       {open && draft && (
-        <div className="coh-overlay" onClick={() => setOpen(false)}>
+        <div className="coh-overlay" onClick={closeModal}>
           <div className="coh-modal" onClick={(e) => e.stopPropagation()}>
             <div className="coh-modal-header">
               <span className="coh-modal-title">Edit — Year {currentYear}</span>
-              <button className="coh-close-btn" onClick={() => setOpen(false)}>×</button>
+              <button className="coh-close-btn" onClick={closeModal}>×</button>
             </div>
 
             <div className="coh-modal-body">
@@ -151,7 +181,7 @@ export default function CashOnHandCalc({ currentYear, inputs, result, displayRes
             </div>
 
             <div className="coh-modal-footer">
-              <button className="coh-cancel-btn" onClick={() => setOpen(false)}>Cancel</button>
+              <button className="coh-cancel-btn" onClick={closeModal}>Cancel</button>
               <button className="coh-save-btn" onClick={handleSave}>Save</button>
             </div>
           </div>

--- a/frontend/components/Dashboard/SimControls/SimControls.tsx
+++ b/frontend/components/Dashboard/SimControls/SimControls.tsx
@@ -12,10 +12,7 @@ interface SimControlsProps {
   onSeek: (year: number) => void;
 }
 
-export default function SimControls({
-  currentYear, isPlaying, status, simMax,
-  onPlay, onPause, onReset, onSeek,
-}: SimControlsProps) {
+export default function SimControls({currentYear, isPlaying, status, simMax, onPlay, onPause, onReset, onSeek,}: SimControlsProps) {
   const bgSize = `${(currentYear / simMax) * 100}% 100%`;
 
   return (


### PR DESCRIPTION
Refactored the dashboard simulation layer to use useReducer for atomic state transitions, extracted pure utility functions (getSimParamsAsOf, buildPayload, diffInputs) into utils.ts, and moved constants out of page.tsx. Fixed a bug where the modal was saving all default field values instead of only user-changed fields, and corrected parameter inheritance so simulation inputs correctly accumulate prior year events before play is hit.